### PR TITLE
refactor: make LndClient Supervisor friendly

### DIFF
--- a/.iex.exs
+++ b/.iex.exs
@@ -1,17 +1,12 @@
-LndClient.start_link(nil)
-
 node_uri = System.get_env("NODE") || "localhost:10009"
 cert_path = System.get_env("CERT") || "~/.lnd/tls.cert"
 macaroon_path = System.get_env("MACAROON") || "~/.lnd/readonly.macaroon"
 
-case LndClient.connect(node_uri, cert_path, macaroon_path) do
-  { :ok, _connection } ->
-    IO.puts "SUCCESS: connected to node"
-
-  { :error, error } ->
-    IO.puts "ERROR: cannot connect to node"
-    IO.inspect error
-end
+conn_config = %LndClient.ConnConfig{
+  node_uri: node_uri,
+  cert_path: cert_path,
+  macaroon_path: macaroon_path,
+} |> LndClient.start_link
 
 LndClient.Tools.HtlcUpdates.start_link
 LndClient.Tools.InvoiceUpdates.start_link

--- a/lib/connectivity.ex
+++ b/lib/connectivity.ex
@@ -1,17 +1,15 @@
 defmodule LndClient.Connectivity do
-  def connect(%{
-    node_uri: node_uri,
-    cert_path: cert_path,
-    macaroon_path: macaroon_path
-  }) do
-    creds = get_creds(cert_path)
+  alias LndClient.ConnConfig
+
+  def connect(%ConnConfig{} = conn_config) do
+    creds = get_creds(conn_config.cert_path)
 
     GRPC.Stub.connect(
-      node_uri,
+      conn_config.node_uri,
       cred: creds,
       adapter_opts: %{http2_opts: %{keepalive: :infinity}}
     )
-    |> manage_new_connection(macaroon_path)
+    |> manage_new_connection(conn_config.macaroon_path)
   end
 
   def disconnect(channel) do

--- a/lib/lnd_client.ex
+++ b/lib/lnd_client.ex
@@ -51,8 +51,8 @@ defmodule LndClient do
   """
   def start_link(%ConnConfig{} = conn_config) do
     case GenServer.start_link(__MODULE__, init_state(conn_config), name: __MODULE__) do
-      {:ok, pid} = result ->
-        connect
+      {:ok, _pid} = result ->
+        connect()
         result
       result -> result
     end

--- a/lib/lnd_client.ex
+++ b/lib/lnd_client.ex
@@ -217,7 +217,7 @@ defmodule LndClient do
   def handle_call(:connect, _from, state) do
     conn_config = Map.get(state, :conn_config)
 
-    case Connectivity.connect(conn_config |> Map.from_struct) do
+    case Connectivity.connect(conn_config) do
       { :ok, %{ connection: connection, macaroon: macaroon } } = result ->
           { :reply, result, state
           |> Map.put(:connection, connection)

--- a/lib/lnd_client/conn_config.ex
+++ b/lib/lnd_client/conn_config.ex
@@ -1,0 +1,3 @@
+defmodule LndClient.ConnConfig do
+  defstruct [:node_uri, :cert_path, :macaroon_path]
+end


### PR DESCRIPTION
One can pass something like this to a Supervisor:

```ex
{
  LndClient,
  %LndClient.ConnConfig{
    node_uri: System.get_env("NODE_URI"),
    cert_path: System.get_env("CERT_PATH"),
    macaroon_path: System.get_env("MACAROON_PATH")
  },
},
```

This addresses https://github.com/RooSoft/lnd_client/issues/10, but:
- not the comment about restarting when it is disconnected -- that is to follow!
- not naming the genserver in the scenario that one would need to connect to multiple

Tested locally with Polar.