### PR TITLE
fix: unable to start GenServer specifying LndClient

### DIFF
--- a/lib/lnd_client.ex
+++ b/lib/lnd_client.ex
@@ -23,6 +23,13 @@ defmodule LndClient do
     GenServer.start(@server, init_state(conn_config), name: @server)
   end
 
+  def child_spec(arg) do
+    %{
+      id: __MODULE__,
+      start: {__MODULE__, :start_link, [arg]}
+    }
+  end
+
   @doc """
   Starts a process which connects to an LND instance.
 

--- a/test/lnd_client_test.exs
+++ b/test/lnd_client_test.exs
@@ -1,0 +1,12 @@
+defmodule LndClientTest do
+  use ExUnit.Case
+
+  test "child_spec is defined make it cleaner starting from a Supervisor" do
+    expected_result = %{
+      id: LndClient,
+      start: {LndClient, :start_link, ["1"]}
+    }
+
+    assert LndClient.child_spec("1") == expected_result
+  end
+end


### PR DESCRIPTION
324925f6a22ea768fc2673a91c13cf35d4baba56 broke passing in `LndClient` as a module to start.