### PR TITLE
test: remove SSL warning

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,0 +1,3 @@
+import Config
+
+config :lnd_client, :env, config_env()

--- a/lib/connectivity.ex
+++ b/lib/connectivity.ex
@@ -29,12 +29,24 @@ defmodule LndClient.Connectivity do
   defp get_creds(cert_path) do
     filename = Path.expand(cert_path)
 
-    GRPC.Credential.new(ssl: [cacertfile: filename])
+    ssl_opts =
+      [cacertfile: filename]
+      |> append_verify_settings
+
+    GRPC.Credential.new(ssl: ssl_opts)
   end
 
   defp get_macaroon(macaroon_path) do
     filename = Path.expand(macaroon_path)
 
     File.read!(filename) |> Base.encode16()
+  end
+
+  defp append_verify_settings(list) do
+    list |> append_if(Application.get_env(:lnd_client, :env) == :test, verify: :verify_none)
+  end
+
+  defp append_if(list, condition, item) do
+    if condition, do: list ++ [item], else: list
   end
 end


### PR DESCRIPTION
```
Authenticity is not established by certificate path validation
```

Similar to [this issue](https://github.com/open-telemetry/opentelemetry-erlang/pull/266). Looking through their links and changes, I found that they [disable verification](https://github.com/open-telemetry/opentelemetry-erlang/pull/266/files#diff-0f51934e6a3d8a5c6afe859dfa8292330f62d28c7584a2a750fc66cd3ccb84e1R50).

Looking for the setting for grpc, I found it [here](https://github.com/elixir-grpc/grpc/blob/1e0598b6995adb4f3d1cc01cf67f3614ae7ca376/test/support/factory.ex#L46)