### PR TITLE
feat: `.add_hold_invoice`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `get_forwarding_history`
   - `decode_payment_request`
   - `update_channel_policy`
+- `.add_hold_invoice`
 
 ### Changed
 - `LndClient.child_spec` accepts a keyword list. see "How to use it with a Supervisor" in the [README](/README.md#how-to-use-it-with-a-supervisor).

--- a/README.md
+++ b/README.md
@@ -174,9 +174,11 @@ cd proto
 
 curl -O https://raw.githubusercontent.com/lightningnetwork/lnd/master/lnrpc/lightning.proto
 curl -O https://raw.githubusercontent.com/lightningnetwork/lnd/master/lnrpc/routerrpc/router.proto
+curl -O https://raw.githubusercontent.com/lightningnetwork/lnd/master/lnrpc/invoicesrpc/invoices.proto
 
 protoc --elixir_out=plugins=grpc:../lib/gRPC lightning.proto
 protoc --elixir_out=plugins=grpc:../lib/gRPC router.proto
+protoc --elixir_out=plugins=grpc:../lib/gRPC invoices.proto
 
 cd ..
 ```

--- a/lib/gRPC/invoices.pb.ex
+++ b/lib/gRPC/invoices.pb.ex
@@ -1,0 +1,100 @@
+defmodule Invoicesrpc.LookupModifier do
+  @moduledoc false
+  use Protobuf, enum: true, protoc_gen_elixir_version: "0.11.0", syntax: :proto3
+
+  field :DEFAULT, 0
+  field :HTLC_SET_ONLY, 1
+  field :HTLC_SET_BLANK, 2
+end
+
+defmodule Invoicesrpc.CancelInvoiceMsg do
+  @moduledoc false
+  use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto3
+
+  field :payment_hash, 1, type: :bytes, json_name: "paymentHash"
+end
+
+defmodule Invoicesrpc.CancelInvoiceResp do
+  @moduledoc false
+  use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto3
+end
+
+defmodule Invoicesrpc.AddHoldInvoiceRequest do
+  @moduledoc false
+  use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto3
+
+  field :memo, 1, type: :string
+  field :hash, 2, type: :bytes
+  field :value, 3, type: :int64
+  field :value_msat, 10, type: :int64, json_name: "valueMsat"
+  field :description_hash, 4, type: :bytes, json_name: "descriptionHash"
+  field :expiry, 5, type: :int64
+  field :fallback_addr, 6, type: :string, json_name: "fallbackAddr"
+  field :cltv_expiry, 7, type: :uint64, json_name: "cltvExpiry"
+  field :route_hints, 8, repeated: true, type: Lnrpc.RouteHint, json_name: "routeHints"
+  field :private, 9, type: :bool
+end
+
+defmodule Invoicesrpc.AddHoldInvoiceResp do
+  @moduledoc false
+  use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto3
+
+  field :payment_request, 1, type: :string, json_name: "paymentRequest"
+  field :add_index, 2, type: :uint64, json_name: "addIndex"
+  field :payment_addr, 3, type: :bytes, json_name: "paymentAddr"
+end
+
+defmodule Invoicesrpc.SettleInvoiceMsg do
+  @moduledoc false
+  use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto3
+
+  field :preimage, 1, type: :bytes
+end
+
+defmodule Invoicesrpc.SettleInvoiceResp do
+  @moduledoc false
+  use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto3
+end
+
+defmodule Invoicesrpc.SubscribeSingleInvoiceRequest do
+  @moduledoc false
+  use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto3
+
+  field :r_hash, 2, type: :bytes, json_name: "rHash"
+end
+
+defmodule Invoicesrpc.LookupInvoiceMsg do
+  @moduledoc false
+  use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto3
+
+  oneof :invoice_ref, 0
+
+  field :payment_hash, 1, type: :bytes, json_name: "paymentHash", oneof: 0
+  field :payment_addr, 2, type: :bytes, json_name: "paymentAddr", oneof: 0
+  field :set_id, 3, type: :bytes, json_name: "setId", oneof: 0
+
+  field :lookup_modifier, 4,
+    type: Invoicesrpc.LookupModifier,
+    json_name: "lookupModifier",
+    enum: true
+end
+
+defmodule Invoicesrpc.Invoices.Service do
+  @moduledoc false
+  use GRPC.Service, name: "invoicesrpc.Invoices", protoc_gen_elixir_version: "0.11.0"
+
+  rpc :SubscribeSingleInvoice, Invoicesrpc.SubscribeSingleInvoiceRequest, stream(Lnrpc.Invoice)
+
+  rpc :CancelInvoice, Invoicesrpc.CancelInvoiceMsg, Invoicesrpc.CancelInvoiceResp
+
+  rpc :AddHoldInvoice, Invoicesrpc.AddHoldInvoiceRequest, Invoicesrpc.AddHoldInvoiceResp
+
+  rpc :SettleInvoice, Invoicesrpc.SettleInvoiceMsg, Invoicesrpc.SettleInvoiceResp
+
+  rpc :LookupInvoiceV2, Invoicesrpc.LookupInvoiceMsg, Lnrpc.Invoice
+end
+
+defmodule Invoicesrpc.Invoices.Stub do
+  @moduledoc false
+  use GRPC.Stub, service: Invoicesrpc.Invoices.Service
+end

--- a/lib/lnd_client.ex
+++ b/lib/lnd_client.ex
@@ -17,6 +17,8 @@ defmodule LndClient do
     NodeInfoRequest
   }
 
+  alias Invoicesrpc.AddHoldInvoiceRequest
+
   @long_timeout 500_000
   @server LndClient.Server
 
@@ -141,6 +143,22 @@ defmodule LndClient do
   """
   def add_invoice(%Invoice{} = invoice, name \\ @server) do
     GenServer.call(name, {:add_invoice, invoice})
+  end
+
+  @doc """
+  Takes a Invoicesrpc.AddHoldInvoiceRequest struct and adds the invoice to LND
+
+  ## Examples
+
+  iex> hash_bytes = "87550a73354fa8f098632c34268c8d2012708a8f56bc7c08209460fb4a3add0e"
+                    |> String.upcase()
+                    |> Base.decode16!()
+  Invoicesrpc.AddHoldInvoiceRequest{value_msat: 150_000, hash: hash_bytes}
+  |> LndClient.add_hold_invoice()
+  {:ok, %Invoicesrpc.AddHoldInvoiceResp{}}
+  """
+  def add_hold_invoice(%AddHoldInvoiceRequest{} = request, name \\ @server) do
+    GenServer.call(name, {:add_hold_invoice, request})
   end
 
   @doc """

--- a/lib/lnd_client/handlers.ex
+++ b/lib/lnd_client/handlers.ex
@@ -1,0 +1,17 @@
+defmodule LndClient.Handlers do
+  def lightning_service_handler do
+    Application.get_env(
+      :lnd_client,
+      :lightning_service_handler,
+      LndClient.LightningServiceHandler
+    )
+  end
+
+  def invoice_service_handler do
+    Application.get_env(
+      :lnd_client,
+      :invoice_service_handler,
+      LndClient.InvoiceServiceHandler
+    )
+  end
+end

--- a/lib/lnd_client/invoice_service_handler.ex
+++ b/lib/lnd_client/invoice_service_handler.ex
@@ -1,0 +1,15 @@
+defmodule LndClient.InvoiceServiceHandler do
+  alias Invoicesrpc.Invoices.Stub
+  alias Lnrpc.Invoice
+  alias Invoicesrpc.{AddHoldInvoiceRequest, LookupInvoiceMsg}
+
+  def add_hold_invoice(%AddHoldInvoiceRequest{} = request, grpc_channel, macaroon) do
+    Stub.add_hold_invoice(grpc_channel, request, metadata: %{macaroon: macaroon})
+  end
+
+  @callback lookup_invoice_v2(LookupInvoiceMsg.t(), GRPC.Channel.t(), String.t()) ::
+              {:ok, Invoice.t()}
+  def lookup_invoice_v2(%LookupInvoiceMsg{} = request, grpc_channel, macaroon) do
+    Stub.lookup_invoice_v2(grpc_channel, request, metadata: %{macaroon: macaroon})
+  end
+end

--- a/lib/lnd_client/invoice_service_handler.ex
+++ b/lib/lnd_client/invoice_service_handler.ex
@@ -1,8 +1,10 @@
 defmodule LndClient.InvoiceServiceHandler do
   alias Invoicesrpc.Invoices.Stub
   alias Lnrpc.Invoice
-  alias Invoicesrpc.{AddHoldInvoiceRequest, LookupInvoiceMsg}
+  alias Invoicesrpc.{AddHoldInvoiceRequest, LookupInvoiceMsg, AddHoldInvoiceResp}
 
+  @callback add_hold_invoice(AddHoldInvoiceRequest.t(), GRPC.Channel.t(), String.t()) ::
+              {:ok, AddHoldInvoiceResp.t()}
   def add_hold_invoice(%AddHoldInvoiceRequest{} = request, grpc_channel, macaroon) do
     Stub.add_hold_invoice(grpc_channel, request, metadata: %{macaroon: macaroon})
   end

--- a/lib/lnd_client/invoices_handler.ex
+++ b/lib/lnd_client/invoices_handler.ex
@@ -1,0 +1,8 @@
+defmodule LndClient.InvoicesHandler do
+  alias Invoicesrpc.Invoices.Stub
+  alias Invoicesrpc.AddHoldInvoiceRequest
+
+  def add_hold_invoice(%AddHoldInvoiceRequest{} = request, grpc_channel, macaroon) do
+    Stub.add_hold_invoice(grpc_channel, request, metadata: %{macaroon: macaroon})
+  end
+end

--- a/lib/lnd_client/invoices_handler.ex
+++ b/lib/lnd_client/invoices_handler.ex
@@ -1,8 +1,0 @@
-defmodule LndClient.InvoicesHandler do
-  alias Invoicesrpc.Invoices.Stub
-  alias Invoicesrpc.AddHoldInvoiceRequest
-
-  def add_hold_invoice(%AddHoldInvoiceRequest{} = request, grpc_channel, macaroon) do
-    Stub.add_hold_invoice(grpc_channel, request, metadata: %{macaroon: macaroon})
-  end
-end

--- a/lib/lnd_client/server.ex
+++ b/lib/lnd_client/server.ex
@@ -105,6 +105,17 @@ defmodule LndClient.Server do
     {:reply, result, state}
   end
 
+  def handle_call({:add_hold_invoice, request}, _from, state) do
+    result =
+      LndClient.InvoicesHandler.add_hold_invoice(
+        request,
+        state.grpc_channel,
+        state.macaroon
+      )
+
+    {:reply, result, state}
+  end
+
   def handle_call({:send_payment_sync, %SendRequest{} = send_request}, _from, state) do
     result =
       lightning_service_handler().send_payment_sync(

--- a/lib/lnd_client/server.ex
+++ b/lib/lnd_client/server.ex
@@ -3,6 +3,8 @@ defmodule LndClient.Server do
 
   require Logger
 
+  alias LndClient.Handlers
+
   alias LndClient.Models.{
     OpenChannelRequest,
     ListInvoiceRequest,
@@ -96,7 +98,7 @@ defmodule LndClient.Server do
 
   def handle_call({:add_invoice, %Invoice{} = invoice}, _from, state) do
     result =
-      lightning_service_handler().add_invoice(
+      Handlers.lightning_service_handler().add_invoice(
         invoice,
         state.grpc_channel,
         state.macaroon
@@ -107,7 +109,7 @@ defmodule LndClient.Server do
 
   def handle_call({:add_hold_invoice, request}, _from, state) do
     result =
-      LndClient.InvoicesHandler.add_hold_invoice(
+      Handlers.invoice_service_handler().add_hold_invoice(
         request,
         state.grpc_channel,
         state.macaroon
@@ -118,7 +120,7 @@ defmodule LndClient.Server do
 
   def handle_call({:send_payment_sync, %SendRequest{} = send_request}, _from, state) do
     result =
-      lightning_service_handler().send_payment_sync(
+      Handlers.lightning_service_handler().send_payment_sync(
         send_request,
         state.grpc_channel,
         state.macaroon
@@ -204,7 +206,7 @@ defmodule LndClient.Server do
   def handle_call(:get_info, _from, state) do
     {
       :reply,
-      lightning_service_handler().get_info(state.grpc_channel, state.macaroon),
+      Handlers.lightning_service_handler().get_info(state.grpc_channel, state.macaroon),
       state
     }
   end
@@ -460,14 +462,6 @@ defmodule LndClient.Server do
       {:error, error} ->
         {:error, "unable to connect to LND: #{error}"}
     end
-  end
-
-  defp lightning_service_handler do
-    Application.get_env(
-      :lnd_client,
-      :lightning_service_handler,
-      LndClient.LightningServiceHandler
-    )
   end
 
   defp connectivity do

--- a/proto/invoices.proto
+++ b/proto/invoices.proto
@@ -1,0 +1,175 @@
+syntax = "proto3";
+
+import "lightning.proto";
+
+package invoicesrpc;
+
+option go_package = "github.com/lightningnetwork/lnd/lnrpc/invoicesrpc";
+
+// Invoices is a service that can be used to create, accept, settle and cancel
+// invoices.
+service Invoices {
+    /*
+    SubscribeSingleInvoice returns a uni-directional stream (server -> client)
+    to notify the client of state transitions of the specified invoice.
+    Initially the current invoice state is always sent out.
+    */
+    rpc SubscribeSingleInvoice (SubscribeSingleInvoiceRequest)
+        returns (stream lnrpc.Invoice);
+
+    /*
+    CancelInvoice cancels a currently open invoice. If the invoice is already
+    canceled, this call will succeed. If the invoice is already settled, it will
+    fail.
+    */
+    rpc CancelInvoice (CancelInvoiceMsg) returns (CancelInvoiceResp);
+
+    /*
+    AddHoldInvoice creates a hold invoice. It ties the invoice to the hash
+    supplied in the request.
+    */
+    rpc AddHoldInvoice (AddHoldInvoiceRequest) returns (AddHoldInvoiceResp);
+
+    /*
+    SettleInvoice settles an accepted invoice. If the invoice is already
+    settled, this call will succeed.
+    */
+    rpc SettleInvoice (SettleInvoiceMsg) returns (SettleInvoiceResp);
+
+    /*
+    LookupInvoiceV2 attempts to look up at invoice. An invoice can be refrenced
+    using either its payment hash, payment address, or set ID.
+    */
+    rpc LookupInvoiceV2 (LookupInvoiceMsg) returns (lnrpc.Invoice);
+}
+
+message CancelInvoiceMsg {
+    // Hash corresponding to the (hold) invoice to cancel. When using
+    // REST, this field must be encoded as base64.
+    bytes payment_hash = 1;
+}
+message CancelInvoiceResp {
+}
+
+message AddHoldInvoiceRequest {
+    /*
+    An optional memo to attach along with the invoice. Used for record keeping
+    purposes for the invoice's creator, and will also be set in the description
+    field of the encoded payment request if the description_hash field is not
+    being used.
+    */
+    string memo = 1;
+
+    // The hash of the preimage
+    bytes hash = 2;
+
+    /*
+    The value of this invoice in satoshis
+
+    The fields value and value_msat are mutually exclusive.
+    */
+    int64 value = 3;
+
+    /*
+    The value of this invoice in millisatoshis
+
+    The fields value and value_msat are mutually exclusive.
+    */
+    int64 value_msat = 10;
+
+    /*
+    Hash (SHA-256) of a description of the payment. Used if the description of
+    payment (memo) is too long to naturally fit within the description field
+    of an encoded payment request.
+    */
+    bytes description_hash = 4;
+
+    // Payment request expiry time in seconds. Default is 3600 (1 hour).
+    int64 expiry = 5;
+
+    // Fallback on-chain address.
+    string fallback_addr = 6;
+
+    // Delta to use for the time-lock of the CLTV extended to the final hop.
+    uint64 cltv_expiry = 7;
+
+    /*
+    Route hints that can each be individually used to assist in reaching the
+    invoice's destination.
+    */
+    repeated lnrpc.RouteHint route_hints = 8;
+
+    // Whether this invoice should include routing hints for private channels.
+    bool private = 9;
+}
+
+message AddHoldInvoiceResp {
+    /*
+    A bare-bones invoice for a payment within the Lightning Network. With the
+    details of the invoice, the sender has all the data necessary to send a
+    payment to the recipient.
+    */
+    string payment_request = 1;
+
+    /*
+    The "add" index of this invoice. Each newly created invoice will increment
+    this index making it monotonically increasing. Callers to the
+    SubscribeInvoices call can use this to instantly get notified of all added
+    invoices with an add_index greater than this one.
+    */
+    uint64 add_index = 2;
+
+    /*
+    The payment address of the generated invoice. This value should be used
+    in all payments for this invoice as we require it for end to end
+    security.
+    */
+    bytes payment_addr = 3;
+}
+
+message SettleInvoiceMsg {
+    // Externally discovered pre-image that should be used to settle the hold
+    // invoice.
+    bytes preimage = 1;
+}
+
+message SettleInvoiceResp {
+}
+
+message SubscribeSingleInvoiceRequest {
+    reserved 1;
+
+    // Hash corresponding to the (hold) invoice to subscribe to. When using
+    // REST, this field must be encoded as base64url.
+    bytes r_hash = 2;
+}
+
+enum LookupModifier {
+    // The default look up modifier, no look up behavior is changed.
+    DEFAULT = 0;
+
+    /*
+    Indicates that when a look up is done based on a set_id, then only that set
+    of HTLCs related to that set ID should be returned.
+    */
+    HTLC_SET_ONLY = 1;
+
+    /*
+    Indicates that when a look up is done using a payment_addr, then no HTLCs
+    related to the payment_addr should be returned. This is useful when one
+    wants to be able to obtain the set of associated setIDs with a given
+    invoice, then look up the sub-invoices "projected" by that set ID.
+    */
+    HTLC_SET_BLANK = 2;
+}
+
+message LookupInvoiceMsg {
+    oneof invoice_ref {
+        // When using REST, this field must be encoded as base64.
+        bytes payment_hash = 1;
+        bytes payment_addr = 2;
+        bytes set_id = 3;
+    }
+
+    LookupModifier lookup_modifier = 4;
+}

--- a/test/lnd_client/invoices_handler_test.exs
+++ b/test/lnd_client/invoices_handler_test.exs
@@ -1,4 +1,4 @@
-defmodule LndClient.InvoicesHandlerTest do
+defmodule LndClient.InvoiceServiceHandlerTest do
   use ExUnit.Case
 
   test "add_hold_invoice adds a hold invoices" do
@@ -23,7 +23,7 @@ defmodule LndClient.InvoicesHandlerTest do
     # set in metadata; the tests pass if that is commented out
     {:ok, response} =
       %Invoicesrpc.AddHoldInvoiceRequest{value_msat: 150_000, hash: hash_bytes}
-      |> LndClient.InvoicesHandler.add_hold_invoice(grpc_channel, "fakemacaroon")
+      |> LndClient.InvoiceServiceHandler.add_hold_invoice(grpc_channel, "fakemacaroon")
 
     assert response.payment_request == "abcd"
   end

--- a/test/lnd_client/invoices_handler_test.exs
+++ b/test/lnd_client/invoices_handler_test.exs
@@ -1,0 +1,30 @@
+defmodule LndClient.InvoicesHandlerTest do
+  use ExUnit.Case
+
+  test "add_hold_invoice adds a hold invoices" do
+    GrpcMock.defmock(Invoicesrpc.Invoices.ServiceMock, for: Invoicesrpc.Invoices.Service)
+
+    GRPC.Server.start(Invoicesrpc.Invoices.ServiceMock, 50_052)
+
+    {:ok, grpc_channel} = GRPC.Stub.connect("localhost:50052")
+
+    Invoicesrpc.Invoices.ServiceMock
+    |> GrpcMock.expect(:add_hold_invoice, fn req, stream ->
+      Invoicesrpc.AddHoldInvoiceResp.new(payment_request: "abcd")
+    end)
+
+    # hash field of a decoded invoice in hex-encoded byte form
+    hash_bytes =
+      "87550a73354fa8f098632c34268c8d2012708a8f56bc7c08209460fb4a3add0e"
+      |> String.upcase()
+      |> Base.decode16!()
+
+    # This does not test that macaroon is even passed in and
+    # set in metadata; the tests pass if that is commented out
+    {:ok, response} =
+      %Invoicesrpc.AddHoldInvoiceRequest{value_msat: 150_000, hash: hash_bytes}
+      |> LndClient.InvoicesHandler.add_hold_invoice(grpc_channel, "fakemacaroon")
+
+    assert response.payment_request == "abcd"
+  end
+end

--- a/test/lnd_client_test.exs
+++ b/test/lnd_client_test.exs
@@ -110,4 +110,24 @@ defmodule LndClientTest do
 
     assert send_response.payment_hash == "ph"
   end
+
+  @tag :start_genserver
+  test "add_hold_invoice adds a hold invoice" do
+    LndClient.MockInvoiceServiceHandler
+    |> expect(
+      :add_hold_invoice,
+      fn request, _grpc_channel, macaroon ->
+        assert request.value == 1000
+        assert macaroon == "fakedmac"
+
+        {:ok, %Invoicesrpc.AddHoldInvoiceResp{payment_request: "pr"}}
+      end
+    )
+
+    {:ok, response} =
+      %Invoicesrpc.AddHoldInvoiceRequest{value: 1000}
+      |> LndClient.add_hold_invoice()
+
+    assert response.payment_request == "pr"
+  end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -15,3 +15,11 @@ Application.put_env(
   :lightning_service_handler,
   LndClient.MockLightningServiceHandler
 )
+
+Mox.defmock(LndClient.MockInvoiceServiceHandler, for: LndClient.InvoiceServiceHandler)
+
+Application.put_env(
+  :lnd_client,
+  :invoice_service_handler,
+  LndClient.MockInvoiceServiceHandler
+)


### PR DESCRIPTION
See inline docs for testing/usage, but for convenience:

```ex
  hash_bytes = "87550a73354fa8f098632c34268c8d2012708a8f56bc7c08209460fb4a3add0e"
                    |> String.upcase()
                    |> Base.decode16!()
  Invoicesrpc.AddHoldInvoiceRequest{value_msat: 150_000, hash: hash_bytes}
  |> LndClient.add_hold_invoice()
```