### PR TITLE
refactor: invoice updates subscriber

### DIFF
--- a/.iex.exs
+++ b/.iex.exs
@@ -2,13 +2,13 @@ node_uri = System.get_env("NODE") || "localhost:10009"
 cert_path = System.get_env("CERT") || "~/.lnd/tls.cert"
 macaroon_path = System.get_env("MACAROON") || "~/.lnd/readonly.macaroon"
 
-conn_config =
-  %LndClient.ConnConfig{
-    node_uri: node_uri,
-    cert_path: cert_path,
-    macaroon_path: macaroon_path
-  }
-  |> LndClient.start_link()
+conn_config = %LndClient.ConnConfig{
+  node_uri: node_uri,
+  cert_path: cert_path,
+  macaroon_path: macaroon_path
+}
+
+LndClient.start_link(%{conn_config: conn_config})
 
 LndClient.Tools.HtlcUpdates.start_link()
 LndClient.Tools.InvoiceUpdates.start_link()

--- a/.iex.exs
+++ b/.iex.exs
@@ -2,13 +2,14 @@ node_uri = System.get_env("NODE") || "localhost:10009"
 cert_path = System.get_env("CERT") || "~/.lnd/tls.cert"
 macaroon_path = System.get_env("MACAROON") || "~/.lnd/readonly.macaroon"
 
-conn_config = %LndClient.ConnConfig{
-  node_uri: node_uri,
-  cert_path: cert_path,
-  macaroon_path: macaroon_path
+%LndClient.Config{
+  conn_config: %LndClient.ConnConfig{
+    node_uri: node_uri,
+    cert_path: cert_path,
+    macaroon_path: macaroon_path
+  }
 }
-
-LndClient.start_link(%{conn_config: conn_config})
+|> LndClient.start_link()
 
 LndClient.Tools.HtlcUpdates.start_link()
 LndClient.Tools.InvoiceUpdates.start_link()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `LndClient.InvoiceUpdatesSubscriber` behaviour module for easy subscription to invoices
 - `decode_payment_request` to decode a payment request
 - named LndClient GenServers to connect to multiple LNDs
 - the following methods accept the GenServer name, which defaults to `LndClient.Server` if not supplied:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `LndClient.InvoiceUpdatesSubscriber` behaviour module for easy subscription to invoices
+- `LndClient.child_specs` to add to a supervisor to start `LndClient.Server` and all other genservers created with behavior modules such as `LndClient.InvoiceUpdatesSubscriber`
 - `decode_payment_request` to decode a payment request
 - named LndClient GenServers to connect to multiple LNDs
 - the following methods accept the GenServer name, which defaults to `LndClient.Server` if not supplied:
@@ -40,7 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `.add_hold_invoice`
 
 ### Changed
-- `LndClient.child_spec` accepts a keyword list. see "How to use it with a Supervisor" in the [README](/README.md#how-to-use-it-with-a-supervisor).
+- `LndClient.child_spec` accepts a map. see "How to use it with a Supervisor" in the [README](/README.md#how-to-use-it-with-a-supervisor).
 - `LndClient.get_node_info` accepts `Lnrpc.NodeInfoRequest` as the first argument.
 - `LndClient.start_link` and `LndClient.start` accept `LndClient.ConnConfig` struct
 - Remove `LndClient.connect` (`LndClient` connects automatically to LND when it starts up)

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ conn_config = %LndClient.ConnConfig{
 ### Start the server, get node info and then stop the server
 
 ```elixir
-LndClient.start_link(conn_config)
+LndClient.start_link(%{conn_config: conn_config})
 LndClient.get_info
 LndClient.stop
 ```
@@ -79,7 +79,7 @@ LndClient.stop
 You can start multiple GenServers by passing in the name:
 
 ```elixir
-LndClient.start_link(conn_config, BobLndClient)
+LndClient.start_link(%{conn_config: conn_config, name: BobLndClient})
 LndClient.get_info(BobLndClient)
 ```
 
@@ -88,41 +88,17 @@ LndClient.get_info(BobLndClient)
 Add this to the list of children:
 
 ```elixir
-[
-  {
-    LndClient,
-    conn_config: %LndClient.ConnConfig{
-      node_uri: System.get_env("ALICE_NODE"),
-      cert_path: System.get_env("ALICE_CERT"),
-      macaroon_path: System.get_env("ALICE_MACAROON")
-    }
-  }
-]
+children = [
+  # ...
+] ++ LndClient.child_specs(%{conn_config: conn_config})
 ```
 
-If you're going to make more than one connection to an LND, just pass in the name.
+If you're going to make more than one connection to an LND, pass in the name.
 
 ```elixir
-[
-  {
-    LndClient,
-    conn_config: %LndClient.ConnConfig{
-      node_uri: System.get_env("ALICE_NODE"),
-      cert_path: System.get_env("ALICE_CERT"),
-      macaroon_path: System.get_env("ALICE_MACAROON")
-    },
-    name: AliceLndClient
-  },
-  {
-    LndClient,
-    conn_config: %LndClient.ConnConfig{
-      node_uri: System.get_env("BOB_NODE"),
-      cert_path: System.get_env("BOB_CERT"),
-      macaroon_path: System.get_env("BOB_MACAROON")
-    },
-    name: BobLndClient
-  }
-]
+children = [
+  # ...
+] ++ LndClient.child_specs(%{conn_config: alice_conn_config, name: AliceLndClient}) ++ LndClient.child_specs(%{conn_config: bob_conn_config, name: BobLndClient})
 ```
 
 Then, somewhere else in your app:

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ conn_config = %LndClient.ConnConfig{
 ### Start the server, get node info and then stop the server
 
 ```elixir
-LndClient.start_link(%{conn_config: conn_config})
+LndClient.start_link(%LndClient.Config{conn_config: conn_config})
 LndClient.get_info
 LndClient.stop
 ```
@@ -79,7 +79,7 @@ LndClient.stop
 You can start multiple GenServers by passing in the name:
 
 ```elixir
-LndClient.start_link(%{conn_config: conn_config, name: BobLndClient})
+LndClient.start_link(%LndClient.Config{conn_config: conn_config, name: BobLndClient})
 LndClient.get_info(BobLndClient)
 ```
 
@@ -90,7 +90,7 @@ Add this to the list of children:
 ```elixir
 children = [
   # ...
-] ++ LndClient.child_specs(%{conn_config: conn_config})
+] ++ LndClient.child_specs(%LndClient.Config{conn_config: conn_config})
 ```
 
 If you're going to make more than one connection to an LND, pass in the name.
@@ -98,7 +98,7 @@ If you're going to make more than one connection to an LND, pass in the name.
 ```elixir
 children = [
   # ...
-] ++ LndClient.child_specs(%{conn_config: alice_conn_config, name: AliceLndClient}) ++ LndClient.child_specs(%{conn_config: bob_conn_config, name: BobLndClient})
+] ++ LndClient.child_specs(%LndClient.Config{conn_config: alice_conn_config, name: AliceLndClient}) ++ LndClient.child_specs(%LndClient.Config{conn_config: bob_conn_config, name: BobLndClient})
 ```
 
 Then, somewhere else in your app:

--- a/lib/lnd_client.ex
+++ b/lib/lnd_client.ex
@@ -316,8 +316,4 @@ defmodule LndClient do
       config: config
     }
   end
-
-  defp append_if(list, condition, item) do
-    if condition, do: list ++ [item], else: list
-  end
 end

--- a/lib/lnd_client/config.ex
+++ b/lib/lnd_client/config.ex
@@ -1,0 +1,39 @@
+defmodule LndClient.Config do
+  alias LndClient.{Config, ConnConfig}
+
+  @default_lnd_server LndClient.Server
+  @subscriber_keys [:invoice_subscriber]
+
+  defstruct(
+    conn_config: %ConnConfig{},
+    name: @default_lnd_server,
+    invoice_subscriber: nil
+  )
+
+  def subscriber_child_specs(%Config{} = config) do
+    Enum.into(
+      @subscriber_keys,
+      [],
+      fn subscriber_key ->
+        config |> subscriber_child_spec(subscriber_key)
+      end
+    )
+    |> Enum.reject(&is_nil/1)
+  end
+
+  def subscriber_child_spec(
+        %Config{invoice_subscriber: invoice_subscriber, name: name},
+        :invoice_subscriber
+      ) do
+    case invoice_subscriber do
+      nil ->
+        nil
+
+      _ ->
+        %{
+          id: invoice_subscriber,
+          start: {invoice_subscriber, :start_link, [%{lnd_server_name: name}]}
+        }
+    end
+  end
+end

--- a/lib/lnd_client/invoice_updates_subscriber.ex
+++ b/lib/lnd_client/invoice_updates_subscriber.ex
@@ -1,0 +1,75 @@
+defmodule LndClient.InvoiceUpdatesSubscriber do
+  @moduledoc """
+  A behaviour module for implementing a server to listen to invoice updates.
+
+  All you need to do is define your own module and `handle_subscription_update/1`:
+
+      defmodule MyApp.InvoiceUpdates do
+        use LndClient.InvoiceUpdatesSubscriber
+
+        @impl LndClient.InvoiceUpdatesSubscriber
+        def handle_subscription_update(invoice) do
+          IO.puts("Hello from Tools")
+          IO.inspect(invoice)
+        end
+      end
+
+  Then, you can start this in your application by adding `MyApp.InvoiceUpdates`
+  to your Supervisor's children.
+  """
+
+  defmacro __using__(_opts) do
+    quote do
+      require Logger
+      use GenServer
+      @behaviour LndClient.InvoiceUpdatesSubscriber.Behaviour
+
+      def start_link(_opts \\ []) do
+        GenServer.start_link(__MODULE__, nil, name: __MODULE__)
+      end
+
+      def start(opts \\ %{}) do
+        lnd_server_name = opts[:lnd_server_name] || LndClient.Server
+        state = %{lnd_server_name: lnd_server_name, caller: __MODULE__}
+
+        GenServer.start(@server, state, name: get_server_name())
+      end
+
+      def stop(reason \\ :normal, timeout \\ :infinity) do
+        GenServer.stop(__MODULE__, reason, timeout)
+      end
+
+      def init(_) do
+        LndClient.subscribe_invoices(%{pid: self()})
+
+        {:ok, nil}
+      end
+
+      def handle_info(%Lnrpc.Invoice{} = invoice, state) do
+        now = DateTime.utc_now() |> DateTime.to_string()
+
+        IO.puts("---#{now}---")
+        IO.inspect(invoice)
+
+        handle_subscription_update(invoice)
+
+        {:noreply, state}
+      end
+
+      def handle_info(event, state) do
+        IO.puts("--------- got an unknown event")
+        IO.inspect(event)
+
+        {:noreply, state}
+      end
+
+      def handle_subscription_update(invoice) do
+        Logger.info("Got an update for invoice with payment_request: #{invoice.payment_request}")
+      end
+
+      defoverridable handle_subscription_update: 1
+    end
+  end
+
+  @callback handle_subscription_update(Lnrpc.Invoice.t()) :: any()
+end

--- a/lib/lnd_client/invoice_updates_subscriber/impl.ex
+++ b/lib/lnd_client/invoice_updates_subscriber/impl.ex
@@ -1,0 +1,54 @@
+defmodule LndClient.InvoiceUpdatesSubscriber.Impl do
+  require Logger
+
+  alias LndClient.Handlers
+  alias Lnrpc.InvoiceSubscription
+
+  def set_lnd_connection_details(%{lnd_server_name: lnd_server_name} = state) do
+    lnd_client_state = LndClient.get_state(lnd_server_name)
+
+    state
+    |> Map.put(:grpc_channel, lnd_client_state.grpc_channel)
+    |> Map.put(:macaroon, lnd_client_state.macaroon)
+  end
+
+  def stream_invoices(%{caller: caller, grpc_channel: grpc_channel, macaroon: macaroon}) do
+    Handlers.lightning_service_handler().subscribe_invoices(
+      get_invoice_subscription(caller),
+      grpc_channel,
+      macaroon
+    )
+    |> handle_response(caller)
+  end
+
+  defp handle_response(response, caller) do
+    case response do
+      {:ok, stream} ->
+        stream |> decode_stream(to: caller)
+
+      {:error, %GRPC.RPCError{status: 2}} ->
+        Logger.warn("Disconnected from invoice events")
+
+      {:error, error} ->
+        Logger.error("Unknown invoice GRPC error")
+        IO.inspect(error)
+    end
+  end
+
+  defp decode_stream(stream, opts \\ []) do
+    {:ok, caller} = Keyword.fetch(opts, :to)
+
+    stream
+    |> Enum.each(fn
+      {:ok, invoice} ->
+        caller.handle_subscription_update(invoice)
+
+      {:error, _details} ->
+        IO.puts("Error while decoding stream")
+    end)
+  end
+
+  defp get_invoice_subscription(caller) do
+    InvoiceSubscription.new(add_index: caller.get_add_index())
+  end
+end

--- a/lib/lnd_client/invoice_updates_subscriber/server.ex
+++ b/lib/lnd_client/invoice_updates_subscriber/server.ex
@@ -1,0 +1,26 @@
+defmodule LndClient.InvoiceUpdatesSubscriber.Server do
+  use GenServer
+
+  alias LndClient.InvoiceUpdatesSubscriber.Impl
+
+  require Logger
+
+  def init(%{lnd_server_name: lnd_server_name} = state) do
+    GenServer.cast(self(), :set_lnd_client_state)
+    GenServer.cast(self(), :start_subscription)
+
+    {:ok, state}
+  end
+
+  def handle_cast(:set_lnd_client_state, %{lnd_server_name: lnd_server_name} = state) do
+    {:noreply, Impl.set_lnd_connection_details(state)}
+  end
+
+  def handle_cast(:start_subscription, state) do
+    Logger.info("#{inspect(__MODULE__)}: monitoring for invoices...")
+
+    Impl.stream_invoices(state)
+
+    {:noreply, state}
+  end
+end

--- a/lib/lnd_client/lightning_service_handler.ex
+++ b/lib/lnd_client/lightning_service_handler.ex
@@ -30,4 +30,14 @@ defmodule LndClient.LightningServiceHandler do
       metadata: %{macaroon: macaroon}
     )
   end
+
+  @callback subscribe_invoices(Lnrpc.InvoiceSubscription.t(), GRPC.Channel.t(), String.t()) ::
+              {:ok, {Lnrpc.Invoice.t(), true}}
+  def subscribe_invoices(request \\ Lnrpc.InvoiceSubscription.new(), channel, macaroon) do
+    Lnrpc.Lightning.Stub.subscribe_invoices(
+      channel,
+      request,
+      metadata: %{macaroon: macaroon}
+    )
+  end
 end

--- a/lib/lnd_client/server.ex
+++ b/lib/lnd_client/server.ex
@@ -3,7 +3,7 @@ defmodule LndClient.Server do
 
   require Logger
 
-  alias LndClient.Handlers
+  alias LndClient.{Config, Handlers}
 
   alias LndClient.Models.{
     OpenChannelRequest,
@@ -434,9 +434,7 @@ defmodule LndClient.Server do
     connectivity().disconnect(grpc_channel)
   end
 
-  defp connect_to_lnd(state) do
-    conn_config = Map.get(state, :conn_config)
-
+  defp connect_to_lnd(%{config: %Config{conn_config: conn_config}} = state) do
     case connectivity().connect(conn_config) do
       {:ok, %{grpc_channel: grpc_channel, macaroon: macaroon}} ->
         new_state =

--- a/lib/tools/invoice_updates.ex
+++ b/lib/tools/invoice_updates.ex
@@ -1,33 +1,9 @@
 defmodule LndClient.Tools.InvoiceUpdates do
-  use GenServer
+  use LndClient.InvoiceUpdatesSubscriber
 
-  def start_link() do
-    GenServer.start_link(__MODULE__, nil, name: __MODULE__)
-  end
-
-  def stop(reason \\ :normal, timeout \\ :infinity) do
-    GenServer.stop(__MODULE__, reason, timeout)
-  end
-
-  def init(_) do
-    LndClient.subscribe_invoices(%{pid: self()})
-
-    {:ok, nil}
-  end
-
-  def handle_info(%Lnrpc.Invoice{} = invoice_subscription, state) do
-    now = DateTime.utc_now() |> DateTime.to_string()
-
-    IO.puts("---#{now}---")
-    IO.inspect(invoice_subscription)
-
-    {:noreply, state}
-  end
-
-  def handle_info(event, state) do
-    IO.puts("--------- got an unknown event")
-    IO.inspect(event)
-
-    {:noreply, state}
+  @impl LndClient.InvoiceUpdatesSubscriber
+  def handle_subscription_update(invoice) do
+    IO.puts("Hello from Tools")
+    IO.inspect(invoice)
   end
 end

--- a/lib/tools/invoice_updates.ex
+++ b/lib/tools/invoice_updates.ex
@@ -3,7 +3,11 @@ defmodule LndClient.Tools.InvoiceUpdates do
 
   @impl LndClient.InvoiceUpdatesSubscriber
   def handle_subscription_update(invoice) do
-    IO.puts("Hello from Tools")
+    IO.puts("Hello from Tools, starting from add index #{get_add_index()}")
     IO.inspect(invoice)
+  end
+
+  def get_add_index do
+    31
   end
 end

--- a/test/lnd_client/config_test.exs
+++ b/test/lnd_client/config_test.exs
@@ -1,0 +1,45 @@
+defmodule LndClient.ConfigTest do
+  use ExUnit.Case
+  alias LndClient.Config
+
+  test "subscriber_child_specs/1 returns child specs of subscriber modules when given" do
+    config = %Config{invoice_subscriber: TestInvoiceSubscriber, name: :bob}
+
+    resulting_child_specs = config |> Config.subscriber_child_specs()
+
+    expected_child_specs = [Config.subscriber_child_spec(config, :invoice_subscriber)]
+
+    assert resulting_child_specs == expected_child_specs
+  end
+
+  test "subscriber_child_specs/1 ignores nil subscribers" do
+    config = %Config{}
+
+    resulting_child_specs = config |> Config.subscriber_child_specs()
+
+    assert resulting_child_specs == []
+  end
+
+  test "subscriber_child_spec(:invoice_subscriber) given a module returns a valid child_spec" do
+    config = %Config{invoice_subscriber: TestInvoiceSubscriber, name: :alice}
+
+    expected_child_spec = %{
+      id: TestInvoiceSubscriber,
+      start: {TestInvoiceSubscriber, :start_link, [%{lnd_server_name: :alice}]}
+    }
+
+    resulting_child_spec =
+      config
+      |> Config.subscriber_child_spec(:invoice_subscriber)
+
+    assert resulting_child_spec == expected_child_spec
+  end
+
+  test "subscriber_child_spec(:invoice_subscriber) not given a module returns nil" do
+    config = %Config{}
+
+    resulting_config = config |> Config.subscriber_child_spec(:invoice_subscriber)
+
+    assert resulting_config == nil
+  end
+end

--- a/test/lnd_client/lightning_service_handler_test.exs
+++ b/test/lnd_client/lightning_service_handler_test.exs
@@ -46,4 +46,32 @@ defmodule LndClient.LightningServiceHandlerTest do
 
     assert response.payment_request == "pr"
   end
+
+  test "subscribe_invoices/3 streams invoices updates", %{grpc_channel: grpc_channel} do
+    Lnrpc.Lightning.ServiceMock
+    |> GrpcMock.expect(:subscribe_invoices, fn request, _stream ->
+      assert request.add_index == 2
+
+      %Lnrpc.Invoice{payment_request: "pr"}
+    end)
+
+    request = Lnrpc.InvoiceSubscription.new(add_index: 2)
+
+    # This does not test that macaroon is even passed in and
+    # set in metadata; the tests pass if that is commented out
+    {:ok, response} = @handler.subscribe_invoices(request, grpc_channel, "fakemacaroon")
+
+    IO.inspect(response)
+
+    # TODO Test the stream of invoice/s. How?
+    # response
+    # |> Enum.each(fn
+    #   {:ok, invoice} ->
+    #     IO.puts("Got invoice baby:")
+    #     IO.inspect(invoice)
+
+    #   {:error, _details} ->
+    #     IO.puts("Error while decoding stream")
+    # end)
+  end
 end

--- a/test/lnd_client_test.exs
+++ b/test/lnd_client_test.exs
@@ -38,7 +38,7 @@ defmodule LndClientTest do
         macaroon_path: "macaroon_path"
       }
 
-      LndClient.start_link(conn_config)
+      LndClient.start_link(%{conn_config: conn_config})
     end
 
     :ok
@@ -65,7 +65,8 @@ defmodule LndClientTest do
 
     expected_result = %{
       id: :alice_lnd,
-      start: {LndClient, :start_link, [conn_config, :alice_lnd]}
+      start:
+        {LndClient, :start_link, [%{conn_config: conn_config, name: :alice_lnd, subscribers: []}]}
     }
 
     assert LndClient.child_spec(%{conn_config: conn_config, name: :alice_lnd}) == expected_result

--- a/test/support/test_invoice_subscriber.exs
+++ b/test/support/test_invoice_subscriber.exs
@@ -1,0 +1,3 @@
+defmodule TestInvoiceSubscriber do
+  use LndClient.InvoiceUpdatesSubscriber
+end


### PR DESCRIPTION
Simplify the setup to subscribe to invoice updates.

1. Create a module using `LndClient.InvoiceUpdatesSubscriber` like so:

```ex
defmodule MyApp.LNDInvoiceSubscriber do
  use LndClient.InvoiceUpdatesSubscriber

  @impl LndClient.InvoiceUpdatesSubscriber
  def handle_subscription_update(invoice) do
    # Put app-specific code here
    IO.inspect(invoice)
  end

  # Optional: return the index to resume from
  @impl LndClient.InvoiceUpdatesSubscriber
  def get_add_index do
    # Fetch from the database and return an integer
  end
end
```

2. Tell your supervisor how to start `LndClient`:

Note: Because there is more config, there's a dedicated config struct `LndClient.Config`.

```ex
LndClient.child_specs(
  %LndClient.Config{
    conn_config: %LndClient.ConnConfig{
      node_uri: System.get_env("NODE"),
      cert_path: System.get_env("CERT"),
      macaroon_path: System.get_env("MACAROON")
    },
    invoice_subscriber: MyApp.LNDInvoiceSubscriber
  }
)
```
