### PR TITLE
wip Subscribe single invoice

### DIFF
--- a/.iex.subscribe-single-invoice.exs
+++ b/.iex.subscribe-single-invoice.exs
@@ -10,7 +10,7 @@ defmodule SingleSubscriber do
 
   @impl LndClient.SingleInvoiceUpdatesSubscriber
   def handle_subscription_update(invoice) do
-    IO.puts("Hello from Tools")
+    IO.puts("Single invoice subscription update:")
     IO.inspect(invoice)
   end
 end
@@ -26,11 +26,49 @@ end
 }
 |> LndClient.start_link()
 
-LndClient.SingleInvoiceSubscription.DynamicSupervisor.start_link(%{name: :alice})
+case LndClient.SingleInvoiceSubscription.DynamicSupervisor.start_link(%{
+       name: :"LndClient.SingleInvoiceSubscription.DynamicSupervisor.alice"
+     }) do
+  {:ok, ds_pid} -> IO.puts("Started DynamicSupervisor with pid #{inspect(ds_pid)}")
+  {:error, reason} -> IO.puts("Failed to start DynamicSupervisor: #{inspect(reason)}")
+end
 
 pr =
-  "lnbcrt500u1p36apcrpp56xjpxsglm2xrg9q869nd74gtzhne338dcw4zcdwfahrtm8gndwdqdqqcqzpgxqyz5vqsp50tf4730er4snqmx57flctteuzzlgg8cdmh3umcnht2hew0xtrseq9qyyssq4t4ry38vy42zsf8wmyrf0yt2d5za3q3gqe4jc3tdrnp7czjj0q74k0dl0h2aa8xad05j5zuq5wg2cjhpsc4x4pwawvepysx8yskrq3cpxvjdft"
+  "lnbcrt500u1p36l0ahpp5d9ufvhepuc805993ymqmg0jn03kphz5m2m38f2svzcxakzjesqvqdqqcqzpgxqyz5vqsp5g2a7wvca27w6ku0v93xx0kncr6t9ymtkzujq92n3je9hdd0gwu9q9qyyssqk3ggdskn55clu0zc9j3x6uea4x0mszn5ncmuwjkhfgcl2cplraynuanwgfthu75sx2hyww2fseyr9ctkuayg75aa5w7q99cqcskzx8qpgr5tz4"
 
-{:ok, %Lnrpc.PayReq{}} =
-  pr
-  |> LndClient.decode_payment_request(:alice)
+{:ok, pay_req} = pr |> LndClient.decode_payment_request(:alice)
+
+payment_hash_bytes =
+  pay_req.payment_hash
+  |> String.upcase()
+  |> Base.decode16!()
+
+lookup_invoice_msg = %Invoicesrpc.LookupInvoiceMsg{
+  invoice_ref: {:payment_hash, payment_hash_bytes}
+}
+
+inspect(lookup_invoice_msg)
+
+{:ok, invoice} =
+  lookup_invoice_msg
+  |> LndClient.lookup_invoice_v2(:alice)
+
+subscribe_single_invoice_request = %Invoicesrpc.SubscribeSingleInvoiceRequest{
+  r_hash: invoice.r_hash
+}
+
+LndClient.SingleInvoiceSubscription.DynamicSupervisor.add_subscriber(
+  :alice,
+  SingleSubscriber,
+  subscribe_single_invoice_request
+)
+
+# NOTES: when system is restarted, we may miss some updates. How do we recover in a stateless manner?
+#
+# List all invoices to know the latest status?
+# How do we know when to stop and not go back since the beginning of the node's db?
+# How do we know which ones to watch again, because single invoice updates are needed only for hold invoices? What if we watch all? Elixir can handle that anyway.
+#
+# It seems like we ought to leave that to the dev, but we must provide a way for them to hook into the start up process so that they can:
+# - fetch what invoices they want to watch from their db and subscribe to those
+# - get updates for each of the invoices they care about for any updates they may have missed

--- a/.iex.subscribe-single-invoice.exs
+++ b/.iex.subscribe-single-invoice.exs
@@ -1,0 +1,36 @@
+node_uri = System.get_env("NODE") || "127.0.0.1:10003"
+cert_path = System.get_env("CERT") || "/Users/ramon/.polar/networks/1/volumes/lnd/alice/tls.cert"
+
+macaroon_path =
+  System.get_env("MACAROON") ||
+    "/Users/ramon/.polar/networks/1/volumes/lnd/alice/data/chain/bitcoin/regtest/admin.macaroon"
+
+defmodule SingleSubscriber do
+  use LndClient.SingleInvoiceUpdatesSubscriber
+
+  @impl LndClient.SingleInvoiceUpdatesSubscriber
+  def handle_subscription_update(invoice) do
+    IO.puts("Hello from Tools")
+    IO.inspect(invoice)
+  end
+end
+
+%LndClient.Config{
+  conn_config: %LndClient.ConnConfig{
+    node_uri: node_uri,
+    cert_path: cert_path,
+    macaroon_path: macaroon_path
+  },
+  single_invoice_subscriber: SingleSubscriber,
+  name: :alice
+}
+|> LndClient.start_link()
+
+LndClient.SingleInvoiceSubscription.DynamicSupervisor.start_link(%{name: :alice})
+
+pr =
+  "lnbcrt500u1p36apcrpp56xjpxsglm2xrg9q869nd74gtzhne338dcw4zcdwfahrtm8gndwdqdqqcqzpgxqyz5vqsp50tf4730er4snqmx57flctteuzzlgg8cdmh3umcnht2hew0xtrseq9qyyssq4t4ry38vy42zsf8wmyrf0yt2d5za3q3gqe4jc3tdrnp7czjj0q74k0dl0h2aa8xad05j5zuq5wg2cjhpsc4x4pwawvepysx8yskrq3cpxvjdft"
+
+{:ok, %Lnrpc.PayReq{}} =
+  pr
+  |> LndClient.decode_payment_request(:alice)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `decode_payment_request`
   - `update_channel_policy`
 - `.add_hold_invoice`
+- `.lookup_invoice_v2`
 
 ### Changed
 - `LndClient.child_spec` accepts a map. see "How to use it with a Supervisor" in the [README](/README.md#how-to-use-it-with-a-supervisor).

--- a/lib/lnd_client.ex
+++ b/lib/lnd_client.ex
@@ -17,7 +17,7 @@ defmodule LndClient do
     NodeInfoRequest
   }
 
-  alias Invoicesrpc.AddHoldInvoiceRequest
+  alias Invoicesrpc.{AddHoldInvoiceRequest, SubscribeSingleInvoiceRequest, LookupInvoiceMsg}
 
   @long_timeout 500_000
   @server LndClient.Server
@@ -307,6 +307,15 @@ defmodule LndClient do
         max_htlc_msat: max_htlc_msat
       }
     })
+  end
+
+  # TODO testme
+  def add_single_invoice_subscription(%SubscribeSingleInvoiceRequest{} = request, name \\ @server) do
+    GenServer.cast(name, {:subscribe_single_invoice, request})
+  end
+
+  def lookup_invoice_v2(%LookupInvoiceMsg{} = request, name \\ @server) do
+    GenServer.call(name, {:lookup_invoice_v2, request})
   end
 
   defp init_state(%Config{} = config) do

--- a/lib/lnd_client/config.ex
+++ b/lib/lnd_client/config.ex
@@ -2,12 +2,14 @@ defmodule LndClient.Config do
   alias LndClient.{Config, ConnConfig}
 
   @default_lnd_server LndClient.Server
-  @subscriber_keys [:invoice_subscriber]
+  @subscriber_keys [:invoice_subscriber, :single_invoice_subscriber]
+  @single_invoice_dynamic_supervisor LndClient.SingleInvoiceSubscription.DynamicSupervisor
 
   defstruct(
     conn_config: %ConnConfig{},
     name: @default_lnd_server,
-    invoice_subscriber: nil
+    invoice_subscriber: nil,
+    single_invoice_subscriber: nil
   )
 
   def subscriber_child_specs(%Config{} = config) do
@@ -35,5 +37,29 @@ defmodule LndClient.Config do
           start: {invoice_subscriber, :start_link, [%{lnd_server_name: name}]}
         }
     end
+  end
+
+  def subscriber_child_spec(
+        %Config{single_invoice_subscriber: invoice_subscriber, name: name},
+        :single_invoice_subscriber
+      ) do
+    case invoice_subscriber do
+      nil ->
+        nil
+
+      _ ->
+        %{
+          id: custom_module_name(@single_invoice_dynamic_supervisor, name),
+          start: {
+            @single_invoice_dynamic_supervisor,
+            :start_link,
+            [%{extra_arguments: %{lnd_server_name: name}}]
+          }
+        }
+    end
+  end
+
+  defp custom_module_name(module, lnd_client_name) do
+    "#{inspect(module)}.#{lnd_client_name}" |> String.to_atom()
   end
 end

--- a/lib/lnd_client/config.ex
+++ b/lib/lnd_client/config.ex
@@ -44,22 +44,8 @@ defmodule LndClient.Config do
         :single_invoice_subscriber
       ) do
     case invoice_subscriber do
-      nil ->
-        nil
-
-      _ ->
-        %{
-          id: custom_module_name(@single_invoice_dynamic_supervisor, name),
-          start: {
-            @single_invoice_dynamic_supervisor,
-            :start_link,
-            [%{extra_arguments: %{lnd_server_name: name}}]
-          }
-        }
+      nil -> nil
+      _ -> @single_invoice_dynamic_supervisor.child_spec(name)
     end
-  end
-
-  defp custom_module_name(module, lnd_client_name) do
-    "#{inspect(module)}.#{lnd_client_name}" |> String.to_atom()
   end
 end

--- a/lib/lnd_client/config.ex
+++ b/lib/lnd_client/config.ex
@@ -20,6 +20,8 @@ defmodule LndClient.Config do
         config |> subscriber_child_spec(subscriber_key)
       end
     )
+    # TODO testme
+    |> ListUtils.append(single_invoice_subscription_registry_child_spec(config))
     |> Enum.reject(&is_nil/1)
   end
 
@@ -47,5 +49,26 @@ defmodule LndClient.Config do
       nil -> nil
       _ -> @single_invoice_dynamic_supervisor.child_spec(name)
     end
+  end
+
+  defp single_invoice_subscription_registry_child_spec(%Config{
+         name: name,
+         single_invoice_subscriber: single_invoice_subscriber
+       }) do
+    case single_invoice_subscriber do
+      nil ->
+        nil
+
+      _ ->
+        {
+          Registry,
+          keys: :unique, name: single_invoice_subscriber_registry_name(name)
+        }
+    end
+  end
+
+  def single_invoice_subscriber_registry_name(lnd_client_name) do
+    "LndClient.SingleInvoiceSubscriptionRegistry.#{lnd_client_name}"
+    |> String.to_atom()
   end
 end

--- a/lib/lnd_client/list_utils.ex
+++ b/lib/lnd_client/list_utils.ex
@@ -1,6 +1,10 @@
 defmodule LndClient.ListUtils do
   def append_if(list, condition, item) do
-    if condition, do: list ++ [item], else: list
+    if condition, do: append(list, item), else: list
+  end
+
+  def append(list, item) do
+    list ++ [item]
   end
 
   def unique_append(list, item) do

--- a/lib/lnd_client/list_utils.ex
+++ b/lib/lnd_client/list_utils.ex
@@ -1,0 +1,10 @@
+defmodule LndClient.ListUtils do
+  def append_if(list, condition, item) do
+    if condition, do: list ++ [item], else: list
+  end
+
+  def unique_append(list, item) do
+    list
+    |> append_if(!Enum.member?(list, item), item)
+  end
+end

--- a/lib/lnd_client/single_invoice_subscription/dynamic_supervisor.ex
+++ b/lib/lnd_client/single_invoice_subscription/dynamic_supervisor.ex
@@ -1,0 +1,59 @@
+defmodule LndClient.SingleInvoiceSubscription.DynamicSupervisor do
+  use DynamicSupervisor
+  @me __MODULE__
+
+  alias Invoicesrpc.SubscribeSingleInvoiceRequest
+
+  def start_link(%{name: name} = args) do
+    IO.puts("Args in DynamicSupervisor:")
+    IO.inspect(args)
+    DynamicSupervisor.start_link(__MODULE__, :no_args, name: name)
+  end
+
+  def init(:no_args) do
+    DynamicSupervisor.init(strategy: :one_for_one)
+  end
+
+  # TODO testme
+  def add_subscriber(
+        lnd_server_name,
+        subscriber_module,
+        %SubscribeSingleInvoiceRequest{} = request
+      ) do
+    {:ok, _pid} =
+      DynamicSupervisor.start_child(
+        custom_server_name(lnd_server_name),
+        subscriber_module,
+        [
+          %LndClient.SingleInvoiceUpdatesSubscriber.State{
+            lnd_server_name: lnd_server_name,
+            request: request,
+            callback_func: &subscriber_module.handle_subscription_update/1
+          }
+        ]
+      )
+  end
+
+  # TODO testme
+  def child_spec(lnd_server_name) do
+    dynamic_supervisor_name = custom_server_name(lnd_server_name)
+
+    %{
+      id: dynamic_supervisor_name,
+      start: {
+        @me,
+        :start_link,
+        [
+          %{
+            name: dynamic_supervisor_name,
+            extra_arguments: %{lnd_server_name: lnd_server_name}
+          }
+        ]
+      }
+    }
+  end
+
+  defp custom_server_name(lnd_server_name) do
+    "#{inspect(__MODULE__)}.#{lnd_server_name}" |> String.to_atom()
+  end
+end

--- a/lib/lnd_client/single_invoice_subscription/dynamic_supervisor.ex
+++ b/lib/lnd_client/single_invoice_subscription/dynamic_supervisor.ex
@@ -30,40 +30,7 @@ defmodule LndClient.SingleInvoiceSubscription.DynamicSupervisor do
       DynamicSupervisor.start_child(
         custom_server_name(lnd_server_name),
         {subscriber_module, state}
-        # %{
-        #   id: subscriber_module,
-        #   start: {
-        #     subscriber_module,
-        #     :start_link,
-        #     [
-        #       %LndClient.SingleInvoiceUpdatesSubscriber.State{
-        #         lnd_server_name: lnd_server_name,
-        #         request: request,
-        #         callback_func: &subscriber_module.handle_subscription_update/1
-        #       }
-        #     ]
-        #   }
-        # }
       )
-  end
-
-  # TODO testme
-  def child_spec(lnd_server_name) do
-    dynamic_supervisor_name = custom_server_name(lnd_server_name)
-
-    %{
-      id: dynamic_supervisor_name,
-      start: {
-        @me,
-        :start_link,
-        [
-          %{
-            name: dynamic_supervisor_name,
-            extra_arguments: %{lnd_server_name: lnd_server_name}
-          }
-        ]
-      }
-    }
   end
 
   defp custom_server_name(lnd_server_name) do

--- a/lib/lnd_client/single_invoice_subscription/dynamic_supervisor.ex
+++ b/lib/lnd_client/single_invoice_subscription/dynamic_supervisor.ex
@@ -20,17 +20,30 @@ defmodule LndClient.SingleInvoiceSubscription.DynamicSupervisor do
         subscriber_module,
         %SubscribeSingleInvoiceRequest{} = request
       ) do
+    state = %LndClient.SingleInvoiceUpdatesSubscriber.State{
+      lnd_server_name: lnd_server_name,
+      request: request,
+      callback_func: &subscriber_module.handle_subscription_update/1
+    }
+
     {:ok, _pid} =
       DynamicSupervisor.start_child(
         custom_server_name(lnd_server_name),
-        subscriber_module,
-        [
-          %LndClient.SingleInvoiceUpdatesSubscriber.State{
-            lnd_server_name: lnd_server_name,
-            request: request,
-            callback_func: &subscriber_module.handle_subscription_update/1
-          }
-        ]
+        {subscriber_module, state}
+        # %{
+        #   id: subscriber_module,
+        #   start: {
+        #     subscriber_module,
+        #     :start_link,
+        #     [
+        #       %LndClient.SingleInvoiceUpdatesSubscriber.State{
+        #         lnd_server_name: lnd_server_name,
+        #         request: request,
+        #         callback_func: &subscriber_module.handle_subscription_update/1
+        #       }
+        #     ]
+        #   }
+        # }
       )
   end
 

--- a/lib/lnd_client/single_invoice_updates_subscriber.ex
+++ b/lib/lnd_client/single_invoice_updates_subscriber.ex
@@ -29,7 +29,7 @@ defmodule LndClient.SingleInvoiceUpdatesSubscriber do
       @me __MODULE__
 
       def start_link(%State{} = state) do
-        GenServer.start_link(@server, state)
+        GenServer.start_link(@server, state, name: )
       end
 
       def start(%State{} = state) do
@@ -45,6 +45,15 @@ defmodule LndClient.SingleInvoiceUpdatesSubscriber do
       end
 
       defoverridable handle_subscription_update: 1
+
+      defp via_tuple(r_hash, lnd_client_name) do
+        {:via, Registry, {registry_name(lnd_client_name), r_hash}}
+      end
+
+      defp registry_name(lnd_client_name) do
+        lnd_client_name
+        |> LndClient.Config.single_invoice_subscriber_registry_name()
+      end
     end
   end
 

--- a/lib/lnd_client/single_invoice_updates_subscriber.ex
+++ b/lib/lnd_client/single_invoice_updates_subscriber.ex
@@ -1,0 +1,47 @@
+defmodule LndClient.SingleInvoiceUpdatesSubscriber do
+  @moduledoc """
+  A behaviour module for implementing a server to listen to invoice updates.
+
+  All you need to do is define your own module and `handle_subscription_update/1`:
+
+      defmodule MyApp.SingleInvoiceUpdates do
+        use LndClient.SingleInvoiceUpdatesSubscriber
+
+        @impl LndClient.SingleInvoiceUpdatesSubscriber
+        def handle_subscription_update(invoice) do
+          IO.puts("Hello from Tools")
+          IO.inspect(invoice)
+        end
+      end
+
+  Then, you can start this in your application by adding `MyApp.SingleInvoiceUpdates`
+  to your Supervisor's children. See `LndClient.child_specs` for an easy way to do this.
+  """
+
+  defmacro __using__(_opts) do
+    quote do
+      alias LndClient.SingleInvoiceUpdatesSubscriber.State
+
+      require Logger
+
+      @behaviour LndClient.SingleInvoiceUpdatesSubscriber
+      @server LndClient.SingleInvoiceUpdatesSubscriber.Server
+
+      def start_link(%State{} = state) do
+        GenServer.start_link(@server, state)
+      end
+
+      def start(%State{} = state) do
+        GenServer.start(@server, state)
+      end
+
+      def handle_subscription_update(invoice) do
+        Logger.info("Got an update for invoice with payment_request: #{inspect(invoice)}")
+      end
+
+      defoverridable handle_subscription_update: 1
+    end
+  end
+
+  @callback handle_subscription_update(Lnrpc.Invoice.t()) :: any()
+end

--- a/lib/lnd_client/single_invoice_updates_subscriber.ex
+++ b/lib/lnd_client/single_invoice_updates_subscriber.ex
@@ -26,6 +26,7 @@ defmodule LndClient.SingleInvoiceUpdatesSubscriber do
 
       @behaviour LndClient.SingleInvoiceUpdatesSubscriber
       @server LndClient.SingleInvoiceUpdatesSubscriber.Server
+      @me __MODULE__
 
       def start_link(%State{} = state) do
         GenServer.start_link(@server, state)
@@ -33,6 +34,10 @@ defmodule LndClient.SingleInvoiceUpdatesSubscriber do
 
       def start(%State{} = state) do
         GenServer.start(@server, state)
+      end
+
+      def child_spec(%State{} = state) do
+        %{id: @me, start: {@me, :start_link, [state]}}
       end
 
       def handle_subscription_update(invoice) do

--- a/lib/lnd_client/single_invoice_updates_subscriber/impl.ex
+++ b/lib/lnd_client/single_invoice_updates_subscriber/impl.ex
@@ -1,0 +1,48 @@
+defmodule LndClient.InvoiceUpdatesSubscriber.Impl do
+  require Logger
+
+  alias LndClient.Handlers
+  alias Invoicesrpc.SubscribeSingleInvoiceRequest
+  alias LndClient.SingleInvoiceUpdatesSubscriber.State
+
+  def stream_invoices(
+        %State{lnd_server_name: lnd_server_name, request: request, callback_func: callback_func} =
+          state
+      ) do
+    lnd_client_state = LndClient.get_state(lnd_server_name)
+
+    Handlers.lightning_service_handler().subscribe_invoices(
+      request,
+      lnd_client_state.grpc_channel,
+      lnd_client_state.macaroon
+    )
+    |> handle_response(callback_func)
+  end
+
+  defp handle_response(response, callback_func) do
+    case response do
+      {:ok, stream} ->
+        stream |> decode_stream(to: callback_func)
+
+      {:error, %GRPC.RPCError{status: 2}} ->
+        Logger.warn("Disconnected from invoice events")
+
+      {:error, error} ->
+        Logger.error("Unknown invoice GRPC error")
+        IO.inspect(error)
+    end
+  end
+
+  defp decode_stream(stream, opts \\ []) do
+    {:ok, callback_func} = Keyword.fetch(opts, :to)
+
+    stream
+    |> Enum.each(fn
+      {:ok, invoice} ->
+        callback_func.(invoice)
+
+      {:error, _details} ->
+        IO.puts("Error while decoding stream")
+    end)
+  end
+end

--- a/lib/lnd_client/single_invoice_updates_subscriber/impl.ex
+++ b/lib/lnd_client/single_invoice_updates_subscriber/impl.ex
@@ -1,4 +1,4 @@
-defmodule LndClient.InvoiceUpdatesSubscriber.Impl do
+defmodule LndClient.SingleInvoiceUpdatesSubscriber.Impl do
   require Logger
 
   alias LndClient.Handlers

--- a/lib/lnd_client/single_invoice_updates_subscriber/server.ex
+++ b/lib/lnd_client/single_invoice_updates_subscriber/server.ex
@@ -1,14 +1,21 @@
 defmodule LndClient.SingleInvoiceUpdatesSubscriber.Server do
   use GenServer
 
+  alias LndClient.Config
   alias LndClient.SingleInvoiceUpdatesSubscriber.{Impl, State}
 
   require Logger
 
   def init(%State{} = state) do
+    GenServer.cast(self(), :register)
     GenServer.cast(self(), :start_subscription)
 
     {:ok, state}
+  end
+
+  def handle_cast(:register, %State{lnd_server_name: lnd_server_name} = state) do
+    registry_name = Config.single_invoice_subscriber_registry_name(lnd_server_name)
+    {:noreply, state}
   end
 
   def handle_cast(:start_subscription, state) do

--- a/lib/lnd_client/single_invoice_updates_subscriber/server.ex
+++ b/lib/lnd_client/single_invoice_updates_subscriber/server.ex
@@ -1,0 +1,26 @@
+defmodule LndClient.SingleInvoiceUpdatesSubscriber.Server do
+  use GenServer
+
+  alias LndClient.SingleInvoiceUpdatesSubscriber.{Impl, State}
+
+  require Logger
+
+  def init(
+        %{
+          lnd_server_name: lnd_server_name,
+          subscribe_single_invoice_request: subscribe_single_invoice_request
+        } = state
+      ) do
+    GenServer.cast(self(), :start_subscription)
+
+    {:ok, state}
+  end
+
+  def handle_cast(:start_subscription, state) do
+    Logger.info("#{inspect(__MODULE__)}: monitoring for invoices...")
+
+    Impl.stream_invoices(state)
+
+    {:noreply, state}
+  end
+end

--- a/lib/lnd_client/single_invoice_updates_subscriber/server.ex
+++ b/lib/lnd_client/single_invoice_updates_subscriber/server.ex
@@ -5,19 +5,14 @@ defmodule LndClient.SingleInvoiceUpdatesSubscriber.Server do
 
   require Logger
 
-  def init(
-        %{
-          lnd_server_name: lnd_server_name,
-          subscribe_single_invoice_request: subscribe_single_invoice_request
-        } = state
-      ) do
+  def init(%State{} = state) do
     GenServer.cast(self(), :start_subscription)
 
     {:ok, state}
   end
 
   def handle_cast(:start_subscription, state) do
-    Logger.info("#{inspect(__MODULE__)}: monitoring for invoices...")
+    Logger.info("#{inspect(__MODULE__)}: monitoring #{inspect(state.request)}...")
 
     Impl.stream_invoices(state)
 

--- a/lib/lnd_client/single_invoice_updates_subscriber/state.ex
+++ b/lib/lnd_client/single_invoice_updates_subscriber/state.ex
@@ -1,0 +1,3 @@
+defmodule LndClient.SingleInvoiceUpdatesSubscriber.State do
+  defstruct [:lnd_server_name, :request, :callback_func]
+end

--- a/test/lnd_client/config_test.exs
+++ b/test/lnd_client/config_test.exs
@@ -42,4 +42,38 @@ defmodule LndClient.ConfigTest do
 
     assert resulting_config == nil
   end
+
+  test "subscriber_child_spec(:single_invoice_subscriber) given a module returns a valid child_spec" do
+    config = %Config{single_invoice_subscriber: TestSingleInvoiceSubscriber, name: :alice}
+
+    expected_name = String.to_atom("LndClient.SingleInvoiceSubscription.DynamicSupervisor.alice")
+
+    expected_child_spec = %{
+      id: expected_name,
+      start: {
+        LndClient.SingleInvoiceSubscription.DynamicSupervisor,
+        :start_link,
+        [
+          %{
+            extra_arguments: %{lnd_server_name: :alice},
+            name: expected_name
+          }
+        ]
+      }
+    }
+
+    resulting_child_spec =
+      config
+      |> Config.subscriber_child_spec(:single_invoice_subscriber)
+
+    assert resulting_child_spec == expected_child_spec
+  end
+
+  test "subscriber_child_spec(:single_invoice_subscriber) not given a module returns nil" do
+    config = %Config{}
+
+    resulting_config = config |> Config.subscriber_child_spec(:single_invoice_subscriber)
+
+    assert resulting_config == nil
+  end
 end

--- a/test/lnd_client/invoices_handler_test.exs
+++ b/test/lnd_client/invoices_handler_test.exs
@@ -9,7 +9,7 @@ defmodule LndClient.InvoiceServiceHandlerTest do
     {:ok, grpc_channel} = GRPC.Stub.connect("localhost:50052")
 
     Invoicesrpc.Invoices.ServiceMock
-    |> GrpcMock.expect(:add_hold_invoice, fn _req, stream ->
+    |> GrpcMock.expect(:add_hold_invoice, fn _req, _stream ->
       Invoicesrpc.AddHoldInvoiceResp.new(payment_request: "abcd")
     end)
 

--- a/test/support/test_single_invoice_subscriber.exs
+++ b/test/support/test_single_invoice_subscriber.exs
@@ -1,0 +1,2 @@
+defmodule TestSingleInvoiceSubscriber do
+end


### PR DESCRIPTION
We have already introduced adding hold invoices via this client, and now we lack the ability to get updates.

Hold Invoice updates do not show up in [SubscribeInvoices](https://lightning.engineering/api-docs/api/lnd/lightning/subscribe-invoices#grpc). To get updates on hold invoices, we have to call [SubscribeSingleInvoice](https://lightning.engineering/api-docs/api/lnd/invoices/subscribe-single-invoice) on each of them.

The idea here is to use a DynamicSupervisor to create a genserver for _each_ hold invoice we want to know about.

When lnd client boots up, it:
1. will call [ListInvoices](https://api.lightning.community/api/lnd/lightning/list-invoices/index.html) to get a list of all invoices
2. subscribes to all invoices, regardless of the state, using a dynamic supervisor to spawn SingleInvoiceSubscriber genservers

Each SubscribeSingleInvoice genserver:
- publishes the current state of each of them, regardless of the state. This avoids missing state updates while it was not being watched. The application using this client must expect that a state may be published more than once. 
- For all states other than `OPEN` and `ACCEPTED` (see [this](https://github.com/lnproxy/lnproxy/blob/main/lnd.go#L152)), shuts down
- Otherwise, publishes changes to the invoice

Notes:
- To make code simpler, use SubscribeSingleInvoice for all invoices, whether they are hold invoices or not.
- Changes here do not include paying the wrapped invoice; that seems like behaviour that belongs on application level